### PR TITLE
Initial for xcat docker image with systemd support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM centos
+
+MAINTAINER The xCAT Project
+
+ENV container docker
+
+ARG xcat_version=latest
+ARG xcat_reporoot=https://xcat.org/files/xcat/repos/yum
+ARG xcat_baseos=rh7
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; \
+     for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+        rm -f /lib/systemd/system/multi-user.target.wants/* && \
+        rm -f /etc/systemd/system/*.wants/* && \
+        rm -f /lib/systemd/system/local-fs.target.wants/* && \
+        rm -f /lib/systemd/system/sockets.target.wants/*udev* && \
+        rm -f /lib/systemd/system/sockets.target.wants/*initctl* && \
+        rm -f /lib/systemd/system/basic.target.wants:/* && \
+        rm -f /lib/systemd/system/anaconda.target.wants/*
+
+RUN mkdir -p /xcatdata/etc/{dhcp,goconserver,xcat} && ln -sf -t /etc /xcatdata/etc/{dhcp,goconserver,xcat} && \
+    mkdir -p /xcatdata/{install,tftpboot} && ln -sf -t / /xcatdata/{install,tftpboot} && \
+    mkdir -p /xcatdata/.xcat && ln -sf -t /root /xcatdata/.xcat
+
+RUN yum install -y -q wget &&\
+    wget ${xcat_reporoot}/${xcat_version}/xcat-core/xcat-core.repo -O /etc/yum.repos.d/xcat-core.repo && \
+    wget ${xcat_reporoot}/${xcat_version}/xcat-dep/${xcat_baseos}/$(uname -m)/xcat-dep.repo -O /etc/yum.repos.d/xcat-dep.repo && \
+    yum install -y \
+       xCAT \
+       openssh-server \
+       rsyslog && \
+    yum clean all
+
+RUN sed -i -e 's|#PermitRootLogin yes|PermitRootLogin yes|g' \
+           -e 's|#UseDNS yes|UseDNS no|g' /etc/ssh/sshd_config && \
+    echo "root:cluster" | chpasswd && \
+    touch /etc/NEEDINIT
+
+RUN systemctl enable httpd && \
+    systemctl enable sshd && \
+    systemctl enable dhcpd && \
+    systemctl enable rsyslog && \
+    systemctl enable xcatd
+
+ADD entrypoint.sh /etc/rc.d/rc.local
+RUN chmod +x /etc/rc.d/rc.local ; systemctl enable rc-local
+
+VOLUME [ "/xcatdata", "/var/log/xcat" ]
+
+CMD [ "/sbin/init" ]
+

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,0 +1,62 @@
+FROM ubuntu:xenial
+
+MAINTAINER The xCAT Project
+
+ENV container docker
+
+ARG xcat_version=latest
+ARG xcat_reporoot=http://xcat.org/files/xcat/repos/apt
+ARG xcat_baseos=xenial
+
+# Don't start any optional services except for the few we need.
+RUN find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \;
+
+RUN mkdir -p /xcatdata/etc/dhcp && rm -rf /etc/dhcp && ln -sf -t /etc /xcatdata/etc/dhcp && \
+    mkdir -p /xcatdata/etc/goconserver && ln -sf -t /etc /xcatdata/etc/goconserver && \
+    mkdir -p /xcatdata/etc/xcat && ln -sf -t /etc /xcatdata/etc/xcat && \
+    mkdir -p /xcatdata/install && ln -sf -t / /xcatdata/install && \
+    mkdir -p /xcatdata/tftpboot && ln -sf -t / /xcatdata/tftpboot && \
+    mkdir -p /xcatdata/.xcat && ln -sf -t /root /xcatdata/.xcat
+
+RUN echo "APT::Get::Install-Recommends \"false\";\nAPT::Get::Install-Suggests \"false\";" >> /etc/apt/apt.conf && \
+    echo "deb [allow-insecure=yes] ${xcat_reporoot}/${xcat_version}/xcat-core  ${xcat_baseos} main" > /etc/apt/sources.list.d/xcat-core.list && \
+    echo "deb [allow-insecure=yes] ${xcat_reporoot}/${xcat_version}/xcat-dep  ${xcat_baseos} main" > /etc/apt/sources.list.d/xcat-dep.list
+
+# Workaround for systemctl issue in postinst script of below package
+RUN apt-get update && apt-get install -y --allow-unauthenticated goconserver xcat-server || \
+    bash -c "cat /dev/null > /var/lib/dpkg/info/xcat-server.postinst; cat /dev/null > /var/lib/dpkg/info/goconserver.postinst;dpkg --configure -a"
+
+RUN apt-get update && apt-get install -y --allow-unauthenticated \
+       xcat \
+       sudo \
+       psmisc \
+       openssh-server \
+       rsyslog && \
+    apt-get clean
+
+RUN sed -i -e 's|PermitRootLogin prohibit-password|PermitRootLogin yes|g' \
+           -e 's|#PermitRootLogin prohibit-password|PermitRootLogin yes|g' \
+           -e 's|#UseDNS yes|UseDNS no|g' /etc/ssh/sshd_config && \
+    echo "root:cluster" | chpasswd && \
+    sudo a2enmod ssl && \
+    ln -s ../sites-available/default-ssl.conf /etc/apache2/sites-enabled/ssl.conf && \
+    touch /etc/NEEDINIT
+
+RUN systemctl enable apache2 && \
+    systemctl enable ssh && \
+    systemctl enable isc-dhcp-server && \
+    systemctl enable rsyslog && \
+    systemctl enable xcatd
+
+ADD entrypoint.sh /etc/rc.d/rc.local
+RUN chmod +x /etc/rc.d/rc.local ; systemctl enable rc-local
+
+VOLUME [ "/xcatdata", "/var/log/xcat" ]
+
+CMD [ "/sbin/init" ]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# xcat-docker
-Dockerfiles for xCAT
+# xCAT Server Container
+## Description
+xCAT is Extreme Cloud Administration Toolkit, xCAT offers complete management for bare-metal based cluster.
+## Building
+#### Build xCAT container based on Centos 7.x
+```
+$ docker build -t xcat .
+```
+#### Build container based on Ubuntu 16.04 (Xenial)
+```
+$ docker build -f Dockerfile.ubuntu -t xcat-ubuntu .
+```
+#### Build container based on Ubuntu 18.04 (Bionic)
+```
+$ docker build --build-arg xcat_basos=bionic -f Dockerfile.ubuntu -t xcat-ubuntu .
+```
+
+## Launching
+#### Using host network
+```
+docker run -d --name xcatmn --network=host --hostname xcatmn --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro xcat
+```
+**Note**: `sshd` service in container cannot be up when using host network, enter the container with:
+```
+docker exec -it xcatmn /bin/bash
+```
+## Volumes
+xCAT container will create `/xcatdata` volume to store configuration and OS distro data, do not use bind mode to overide the volume unless you have backup all initial data from the container image.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,45 @@
+#! /bin/bash
+
+is_ubuntu=$(test -f /etc/debian_version && echo Y)
+[[ -z ${is_ubuntu} ]] && logadm="root:" || logadm="syslog:adm"
+chown -R ${logadm} /var/log/xcat/
+
+#/dev/loop0 and /dev/loop1 will be occupied by docker by default
+#create a loop device if there is no free loop device inside container
+losetup -f >/dev/null 2>&1 || (
+  maxloopdev=$(losetup -a|awk -F: '{print $1}'|sort -f -r|head -n1);
+  maxloopidx=$[${maxloopdev/#\/dev\/loop}];
+  mknod /dev/loop$[maxloopidx+1] -m0660 b 7 $[maxloopidx+1] && echo "no free loop device inside container,created a new loop device /dev/loop$[maxloopidx+1]..."
+)
+
+if [[ -e "/etc/NEEDINIT"  ]]; then
+    echo "initializing xCAT Tables..."
+    xcatconfig -d
+
+    echo "initializing networks table..."
+    tabprune networks -a
+    makenetworks
+
+    rm -f /etc/NEEDINIT
+fi
+
+
+#restore the backuped db on container start to resume the service state
+if [[ -d "/.dbbackup" ]]; then
+        echo "xCAT DB backup directory \"/.dbbackup\" detected, restoring xCAT tables from /.dbbackup/..."
+        restorexCATdb -p /.dbbackup/
+        echo "finished xCAT Tables restore!"
+fi
+
+. /etc/profile.d/xcat.sh
+
+cat /etc/motd
+HOSTIPS=$(ip -o -4 addr show up|grep -v "\<lo\>"|xargs -I{} expr {} : ".*inet \([0-9.]*\).*")
+echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
+echo "welcome to Dockerized xCAT, please login with"
+[[ -n "$HOSTIPS"  ]] && for i in $HOSTIPS; do echo "   ssh root@$i   "; done && echo "The initial password is \"cluster\""
+echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
+
+
+#read -p "press any key to continue..."
+/bin/bash


### PR DESCRIPTION
- centos
```
docker run -d --name xcatmn --network=host --hostname xcatmn --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro xcat-centos
9a0f0935ea53fb31db7b1f01cdbc7677a920d5e37b47a445b9bed951e20bbc43


[root@mid05tor12cn03 xcat-docker]# docker exec -it xcatmn /bin/bash
[root@xcatmn /]# ps -ef --forest
UID         PID   PPID  C STIME TTY          TIME CMD
root       2219      0  0 10:34 ?        00:00:00 /bin/bash
root       2235   2219  0 10:34 ?        00:00:00  \_ ps -ef --forest
root          1      0  0 10:33 ?        00:00:00 /sbin/init
root         22      1  0 10:33 ?        00:00:00 /usr/lib/systemd/systemd-journald
root         32      1  0 10:33 ?        00:00:00 /usr/sbin/rpc.idmapd
root         55      1  0 10:33 ?        00:00:00 /usr/sbin/rsyslogd -n
root         88      1  0 10:33 ?        00:00:00 /usr/sbin/rpc.mountd
root         95      1  0 10:33 ?        00:00:00 /usr/sbin/gssproxy -D
named       102      1  0 10:33 ?        00:00:00 /usr/sbin/named -u named -c /etc/named.conf
root        411      1  0 10:33 ?        00:00:00 /usr/sbin/httpd -DFOREGROUND
apache      500    411  0 10:33 ?        00:00:00  \_ /usr/sbin/httpd -DFOREGROUND
apache      502    411  0 10:33 ?        00:00:00  \_ /usr/sbin/httpd -DFOREGROUND
apache      503    411  0 10:33 ?        00:00:00  \_ /usr/sbin/httpd -DFOREGROUND
apache      505    411  0 10:33 ?        00:00:00  \_ /usr/sbin/httpd -DFOREGROUND
apache      507    411  0 10:33 ?        00:00:00  \_ /usr/sbin/httpd -DFOREGROUND
root       2143      1  0 10:34 ?        00:00:00 /usr/sbin/in.tftpd -v -l -s /tftpboot -m /etc/tftpmapfile4xcat.conf
root       2144      1  0 10:34 ?        00:00:00 xcatd: SSL listener
root       2145   2144  0 10:34 ?        00:00:00  \_ xcatd: DB Access
root       2146   2144  0 10:34 ?        00:00:00  \_ xcatd: UDP listener
root       2148   2146  0 10:34 ?        00:00:00  |   \_ xcatd: Discovery worker
root       2147   2144  0 10:34 ?        00:00:00  \_ xcatd: install monitor
root       2149   2144  0 10:34 ?        00:00:00  \_ xcatd: Command log writer
```
- ubuntu
```
docker run -d --name xcatmn --network=host --hostname xcatmn --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro xcat-xenial
0806bff138aa674322ff857aa986b345bef22cd8ccd3da4738933a5e69e93b20
[root@mid05tor12cn03 xcat-docker]# docker exec -it xcatmn /bin/bash
root@xcatmn:/# ps -ef --forest
UID         PID   PPID  C STIME TTY          TIME CMD
root        442      0  0 10:36 ?        00:00:00 /bin/bash
root        452    442  0 10:36 ?        00:00:00  \_ ps -ef --forest
root          1      0  0 10:36 ?        00:00:00 /sbin/init
root         19      1  0 10:36 ?        00:00:00 /lib/systemd/systemd-journald
root         36      1  0 10:36 ?        00:00:00 /usr/sbin/rpc.idmapd
root         64      1  0 10:36 ?        00:00:00 /usr/sbin/cron -f
message+     65      1  0 10:36 ?        00:00:00 /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation
syslog       71      1  0 10:36 ?        00:00:00 /usr/sbin/rsyslogd -n
daemon       74      1  0 10:36 ?        00:00:00 /usr/sbin/atd -f
bind         78      1  0 10:36 ?        00:00:00 /usr/sbin/named -f -u bind
root        225      1  2 10:36 ?        00:00:00 /bin/sh /etc/init.d/ondemand background
root        387    225  0 10:36 ?        00:00:00  \_ sleep 60
root        296      1  0 10:36 ?        00:00:00 /sbin/rpcbind -f -w
root        306      1  0 10:36 ?        00:00:00 /usr/sbin/rpc.mountd --manage-gids
root        314      1  0 10:36 ?        00:00:00 /usr/sbin/apache2 -k start
www-data    317    314  0 10:36 ?        00:00:00  \_ /usr/sbin/apache2 -k start
www-data    318    314  0 10:36 ?        00:00:00  \_ /usr/sbin/apache2 -k start
root        388      1  0 10:36 ?        00:00:00 /usr/sbin/xinetd -pidfile /run/xinetd.pid -stayalive -inetd_compat -inetd_ipv6
root        416      1  0 10:36 ?        00:00:00 /usr/sbin/in.tftpd -v -l -s /tftpboot -m /etc/tftpmapfile4xcat.conf
root        431      1  0 10:36 ?        00:00:00 xcatd: SSL listener
root        432    431  0 10:36 ?        00:00:00  \_ xcatd: DB Access
root        433    431  0 10:36 ?        00:00:00  \_ xcatd: UDP listener
root        435    433  0 10:36 ?        00:00:00  |   \_ xcatd: Discovery worker
root        434    431  0 10:36 ?        00:00:00  \_ xcatd: install monitor
root        436    431  0 10:36 ?        00:00:00  \_ xcatd: Command log writer
```