### PR TITLE
To resove the issue `which` command is missing in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir -p /xcatdata/etc/{dhcp,goconserver,xcat} && ln -sf -t /etc /xcatdata/e
     mkdir -p /xcatdata/{install,tftpboot} && ln -sf -t / /xcatdata/{install,tftpboot} && \
     mkdir -p /xcatdata/.xcat && ln -sf -t /root /xcatdata/.xcat
 
-RUN yum install -y -q wget &&\
+RUN yum install -y -q wget which &&\
     wget ${xcat_reporoot}/${xcat_version}/xcat-core/xcat-core.repo -O /etc/yum.repos.d/xcat-core.repo && \
     wget ${xcat_reporoot}/${xcat_version}/xcat-dep/${xcat_baseos}/$(uname -m)/xcat-dep.repo -O /etc/yum.repos.d/xcat-dep.repo && \
     yum install -y \


### PR DESCRIPTION
To resolve https://github.com/xcat2/xcat-docker/issues/2
`xcatprobe` depends on `which` command, after its package is installed,  no below errors shown again
```
    Checking HTTP service is configured...                                                                        [FAIL]
        HTTP check need 'wget' tool, please install 'wget' tool and try again
    Checking TFTP service is configured...                                                                        [FAIL]
        TFTP check need 'tftp' tool, please install 'tftp' tool and try again
    Checking DNS service is configured...                                                                         [FAIL]
        DNS check need 'nslookup' tool, please install 'nslookup' tool and try again
    Checking DHCP service is configured...                                                                        [FAIL]
```
UT:  Note,  the new exposed error will not be covered in this PR.
```
[root@f6u07 /]# xcatprobe xcatmn
[mn]: Checking all xCAT daemons are running...                                                                    [ OK ]
[mn]: Checking xcatd can receive command request...                                                               [ OK ]
[mn]: Checking 'site' table is configured...                                                                      [ OK ]
[mn]: No interface provided by '-i' option, detected site table IP attribute 10.6.7.1, checking xCAT configurat...[WARN]
[mn]: If this is incorrect, rerun with -i <ifname> option                                                         [WARN]
[mn]: Checking provision network is configured...                                                                 [ OK ]
[mn]: Checking 'passwd' table is configured...                                                                    [FAIL]
[mn]: There isn't username or password for 'system' in 'passwd' table
[mn]: Checking important directories(installdir,tftpdir) are configured...                                        [ OK ]
[mn]: Checking SELinux is disabled...                                                                             [ OK ]
[mn]: Checking HTTP service is configured...                                                                      [FAIL]
[mn]: Unknown return code of wget <301>.
[mn]: Checking TFTP service is configured...                                                                      [ OK ]
[mn]: Checking DNS service is configured...                                                                       [FAIL]
[mn]: DNS service isn't ready on 10.6.7.1
[mn]: Checking DHCP service is configured...                                                                      [FAIL]
[mn]: makedhcp xcatmntest failed
...
```