### PR TITLE
Missing createrepo package for building kit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN yum install -y -q wget which &&\
        xCAT \
        openssh-server \
        rsyslog \
+       createrepo \
        chrony \
        man && \
     yum clean all


### PR DESCRIPTION
UT:
After installed `createrepo`
```
# xcattest -t addkit_kit
xCAT automated test started at Sat Dec 29 07:02:12 2018
******************************
To detect current test environment
******************************
Detecting: OS = linux
Warning: No compute node defined, can't get ARCH of compute node
Warning: No compute node defined, can't get HCP TYPE of compute node
******************************
loading test cases
******************************
To run:
addkit_kit
******************************
Start to run test cases
******************************
------START::addkit_kit::Time:Sat Dec 29 07:02:13 2018------

RUN:rm -rf /opt/xcat/share/xcat/tools/autotest/testcase/addkit/prodkit [Sat Dec 29 07:02:13 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:cd /opt/xcat/share/xcat/tools/autotest/testcase/addkit;buildkit create prodkit [Sat Dec 29 07:02:13 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Kit template for prodkit created in /opt/xcat/share/xcat/tools/autotest/testcase/addkit/prodkit directory
CHECK:rc == 0	[Pass]

RUN:cd /opt/xcat/share/xcat/tools/autotest/testcase/addkit/prodkit;buildkit buildrepo all [Sat Dec 29 07:02:13 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
Spawning worker 0 with 1 pkgs
Spawning worker 1 with 1 pkgs
Spawning worker 2 with 0 pkgs
Spawning worker 3 with 0 pkgs
Workers Finished
Saving Primary metadata
Saving file lists metadata
Saving other metadata
Generating sqlite DBs
Sqlite DBs complete
CHECK:rc == 0	[Pass]

RUN:cd /opt/xcat/share/xcat/tools/autotest/testcase/addkit/prodkit;buildkit buildtar [Sat Dec 29 07:02:14 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Creating tar file /opt/xcat/share/xcat/tools/autotest/testcase/addkit/prodkit/prodkit-1.0-1.tar.bz2.
Kit tar file /opt/xcat/share/xcat/tools/autotest/testcase/addkit/prodkit/prodkit-1.0-1.tar.bz2 successfully built.
CHECK:rc == 0	[Pass]

RUN:addkit /opt/xcat/share/xcat/tools/autotest/testcase/addkit/prodkit/prodkit-1.0-1.tar.bz2 [Sat Dec 29 07:02:14 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Adding Kit prodkit-1.0-1
Kit prodkit-1.0-1 was successfully added.
CHECK:rc == 0	[Pass]
CHECK:output =~ Adding Kit prodkit-1.0-1	[Pass]
CHECK:output =~ Kit prodkit-1.0-1 was successfully added	[Pass]
CHECK:output !~ error	[Pass]

RUN:tabdump kit|grep prodkit-1.0-1 [Sat Dec 29 07:02:14 2018]
ElapsedTime:1 sec
RETURN rc = 0
OUTPUT:
"prodkit-1.0-1","prodkit","description for prodkit","1.0","1","Linux",,,"/install/kits/prodkit-1.0-1",,
CHECK:rc == 0	[Pass]

RUN:rmkit prodkit-1.0-1 [Sat Dec 29 07:02:15 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:
Removing kit prodkit-1.0-1
Kit prodkit-1.0-1 was successfully removed.

RUN:rm -f /opt/xcat/share/xcat/tools/autotest/testcase/addkit/prodkit/prodkit-1.0-1.tar.bz2 [Sat Dec 29 07:02:15 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

RUN:rm -rf /opt/xcat/share/xcat/tools/autotest/testcase/addkit/prodkit [Sat Dec 29 07:02:15 2018]
ElapsedTime:0 sec
RETURN rc = 0
OUTPUT:

------END::addkit_kit::Passed::Time:Sat Dec 29 07:02:15 2018 ::Duration::2 sec------
------Total: 1 , Failed: 0------

xCAT automated test finished at Sat Dec 29 07:02:15 2018
Please check results in the /opt/xcat/bin/../share/xcat/tools/autotest/result/,
and see /opt/xcat/bin/../share/xcat/tools/autotest/result//failedcases.20181229070212 file for failed cases.
see /opt/xcat/bin/../share/xcat/tools/autotest/result//performance.report.20181229070212 file for time consumption
```