### PR TITLE
refine entrypoint.sh and the method to do the initilizaiton 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,11 @@ RUN yum install -y -q wget which &&\
     yum clean all
 
 RUN sed -i -e 's|#PermitRootLogin yes|PermitRootLogin yes|g' \
+           -e 's|#Port 22|Port 2200|g' \
            -e 's|#UseDNS yes|UseDNS no|g' /etc/ssh/sshd_config && \
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config && \
     echo "root:cluster" | chpasswd && \
-    touch /etc/NEEDINIT
+    mv /xcatdata /xcatdata.NEEDINIT
 
 RUN systemctl enable httpd && \
     systemctl enable sshd && \
@@ -46,11 +47,12 @@ RUN systemctl enable httpd && \
     systemctl enable rsyslog && \
     systemctl enable xcatd
 
-ADD entrypoint.sh /etc/rc.d/rc.local
-RUN chmod +x /etc/rc.d/rc.local ; systemctl enable rc-local
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 ENV XCATROOT /opt/xcat
 ENV PATH="$XCATROOT/bin:$XCATROOT/sbin:$XCATROOT/share/xcat/tools:$PATH" MANPATH="$XCATROOT/share/man:$MANPATH"
 VOLUME [ "/xcatdata", "/var/log/xcat" ]
 
-CMD [ "/sbin/init" ]
+CMD [ "/entrypoint.sh" ]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,14 +3,16 @@
 is_ubuntu=$(test -f /etc/debian_version && echo Y)
 [[ -z ${is_ubuntu} ]] && logadm="root:" || logadm="syslog:adm"
 chown -R ${logadm} /var/log/xcat/
+. /etc/profile.d/xcat.sh
+if [[ -d "/xcatdata.NEEDINIT"  ]]; then
+    echo "initializing xCAT ..."
+    rsync -a /xcatdata.NEEDINIT/ /xcatdata
+    mv /xcatdata.NEEDINI /xcatdata.orig
+    xcatconfig -i
 
-if [[ -e "/etc/NEEDINIT"  ]]; then
-    echo "initializing xCAT Tables..."
-    xcatconfig -d
-
-    echo "initializing networks table..."
-    tabprune networks -a
-    makenetworks
+    #echo "initializing networks table..."
+    #tabprune networks -a
+    #makenetworks
 
     echo "initializing loop devices..."
     # workaround for no loop device could be used by copycds
@@ -19,18 +21,7 @@ if [[ -e "/etc/NEEDINIT"  ]]; then
         test -b /dev/loop$i || mknod /dev/loop$i -m0660 b 7 $i
     done
 
-    rm -f /etc/NEEDINIT
 fi
-
-
-#restore the backuped db on container start to resume the service state
-if [[ -d "/.dbbackup" ]]; then
-        echo "xCAT DB backup directory \"/.dbbackup\" detected, restoring xCAT tables from /.dbbackup/..."
-        restorexCATdb -p /.dbbackup/
-        echo "finished xCAT Tables restore!"
-fi
-
-. /etc/profile.d/xcat.sh
 
 cat /etc/motd
 HOSTIPS=$(ip -o -4 addr show up|grep -v "\<lo\>"|xargs -I{} expr {} : ".*inet \([0-9.]*\).*")
@@ -41,4 +32,4 @@ echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
 
 
 #read -p "press any key to continue..."
-/bin/bash
+exec /sbin/init

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,8 @@ if [[ -d "/xcatdata.NEEDINIT"  ]]; then
     do
         test -b /dev/loop$i || mknod /dev/loop$i -m0660 b 7 $i
     done
-
+    # workaround for missing `switch_macmap` (#13)
+    ln -sf /opt/xcat/bin/xcatclient /opt/xcat/probe/subcmds/bin/switchprobe
 fi
 
 cat /etc/motd

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ chown -R ${logadm} /var/log/xcat/
 if [[ -d "/xcatdata.NEEDINIT"  ]]; then
     echo "initializing xCAT ..."
     rsync -a /xcatdata.NEEDINIT/ /xcatdata
-    mv /xcatdata.NEEDINI /xcatdata.orig
+    mv /xcatdata.NEEDINIT /xcatdata.orig
     xcatconfig -i
 
     #echo "initializing networks table..."


### PR DESCRIPTION
This is to cover the container first starting:
- no need to copy the /xcatdata from the container
- change sshd port to `2200`
- run `xcatconfig -i` to refresh the database and credentials
- workaround the xCAT-probe missing macmap subcommands.