### PR TITLE
Refine the init procedure of xcat container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; \
         rm -f /lib/systemd/system/anaconda.target.wants/*
 
 RUN mkdir -p /xcatdata/etc/{dhcp,goconserver,xcat} && ln -sf -t /etc /xcatdata/etc/{dhcp,goconserver,xcat} && \
-    mkdir -p /xcatdata/{install,tftpboot} && ln -sf -t / /xcatdata/{install,tftpboot} && \
-    mkdir -p /xcatdata/.xcat && ln -sf -t /root /xcatdata/.xcat
+    mkdir -p /xcatdata/{install,tftpboot} && ln -sf -t / /xcatdata/{install,tftpboot}
 
 RUN yum install -y -q wget which &&\
     wget ${xcat_reporoot}/${xcat_version}/$([[ "devel" = "${xcat_version}" ]] && echo 'core-snap' || echo 'xcat-core')/xcat-core.repo -O /etc/yum.repos.d/xcat-core.repo && \
@@ -39,6 +38,7 @@ RUN sed -i -e 's|#PermitRootLogin yes|PermitRootLogin yes|g' \
            -e 's|#UseDNS yes|UseDNS no|g' /etc/ssh/sshd_config && \
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config && \
     echo "root:cluster" | chpasswd && \
+    rm -rf /root/.ssh && \
     mv /xcatdata /xcatdata.NEEDINIT
 
 RUN systemctl enable httpd && \

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ manifest:
 
 help:
 	@echo "make build"
-	@echo "make build USER=xcat2"
-	@echo "make build USER=xcat2 VERSION=latest"
+	@echo "make build USER=xcat"
+	@echo "make push USER=xcat VERSION=latest"
 	@echo "make manifest USER=myname DOCKER_BUILD_MANIFEST=`pwd`/manifest.yml"
 	@echo "make all"
 	@echo "make all ubuntu=1"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,11 +8,16 @@ if [[ -d "/xcatdata.NEEDINIT"  ]]; then
     echo "initializing xCAT ..."
     rsync -a /xcatdata.NEEDINIT/ /xcatdata
     mv /xcatdata.NEEDINIT /xcatdata.orig
-    xcatconfig -i
+    xcatconfig -d
 
     #echo "initializing networks table..."
-    #tabprune networks -a
-    #makenetworks
+    xcatconfig -i
+    XCATBYPASS=1 tabdump site|grep domain || XCATBYPASS=1 chtab key=domain site.value=example.com
+
+    echo "create symbol link for /root/.xcat..."
+    rsync -a /root/.xcat/* /xcatdata/.xcat
+    rm -rf /root/.xcat/
+    ln -sf -t /root /xcatdata/.xcat
 
     echo "initializing loop devices..."
     # workaround for no loop device could be used by copycds
@@ -28,7 +33,7 @@ cat /etc/motd
 HOSTIPS=$(ip -o -4 addr show up|grep -v "\<lo\>"|xargs -I{} expr {} : ".*inet \([0-9.]*\).*")
 echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
 echo "welcome to Dockerized xCAT, please login with"
-[[ -n "$HOSTIPS"  ]] && for i in $HOSTIPS; do echo "   ssh root@$i   "; done && echo "The initial password is \"cluster\""
+[[ -n "$HOSTIPS"  ]] && for i in $HOSTIPS; do echo "   ssh root@$i -p 2200  "; done && echo "The initial password is \"cluster\""
 echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
 
 

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -21,8 +21,7 @@ RUN mkdir -p /xcatdata/etc/dhcp && rm -rf /etc/dhcp && ln -sf -t /etc /xcatdata/
     mkdir -p /xcatdata/etc/goconserver && ln -sf -t /etc /xcatdata/etc/goconserver && \
     mkdir -p /xcatdata/etc/xcat && ln -sf -t /etc /xcatdata/etc/xcat && \
     mkdir -p /xcatdata/install && ln -sf -t / /xcatdata/install && \
-    mkdir -p /xcatdata/tftpboot && ln -sf -t / /xcatdata/tftpboot && \
-    mkdir -p /xcatdata/.xcat && ln -sf -t /root /xcatdata/.xcat
+    mkdir -p /xcatdata/tftpboot && ln -sf -t / /xcatdata/tftpboot
 
 RUN echo "APT::Get::Install-Recommends \"false\";\nAPT::Get::Install-Suggests \"false\";" >> /etc/apt/apt.conf && \
     (xcat_core_repo=$(bash -c "[[ 'devel' = ${xcat_version} ]] && echo 'core-snap' || echo 'xcat-core'");\
@@ -49,7 +48,8 @@ RUN sed -i -e 's|PermitRootLogin prohibit-password|PermitRootLogin yes|g' \
     echo "root:cluster" | chpasswd && \
     sudo a2enmod ssl && \
     ln -s ../sites-available/default-ssl.conf /etc/apache2/sites-enabled/ssl.conf && \
-    touch /etc/NEEDINIT
+    rm -rf /root/.ssh && \
+    mv /xcatdata /xcatdata.NEEDINIT
 
 RUN systemctl enable apache2 && \
     systemctl enable ssh && \
@@ -57,10 +57,10 @@ RUN systemctl enable apache2 && \
     systemctl enable rsyslog && \
     systemctl enable xcatd
 
-ADD entrypoint.sh /etc/rc.d/rc.local
-RUN chmod +x /etc/rc.d/rc.local ; systemctl enable rc-local
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 ENV XCATROOT /opt/xcat
 ENV PATH="$XCATROOT/bin:$XCATROOT/sbin:$XCATROOT/share/xcat/tools:$PATH" MANPATH="$XCATROOT/share/man:$MANPATH"
 VOLUME [ "/xcatdata", "/var/log/xcat" ]
 
-CMD [ "/sbin/init" ]
+CMD [ "/entrypoint.sh" ]


### PR DESCRIPTION
This PR is to fix below issue:
- cleanup .ssh in container image (recommend to mount `.ssh` directory)
- make right symbol link from /root/.xcat to `/xcatdata/.xcat`
- fix the prompt message with sshd port to 2200
- run `xcatconfig -d` first and then `xcatconfig -i` to do the initialization to make sure site.master is updated as only `xcatconfig -i` won't update site table.
- if no `site.domain`, set it to `example.com` 
- update docker file of ubuntu (Not testing it, just to keep the changes are consistent)
