### PR TITLE
simple the steps to create manifest to non-default organization in dockerhub

### DIFF
--- a/manifest/xcat.yml.in
+++ b/manifest/xcat.yml.in
@@ -1,0 +1,10 @@
+image: #ORGNAME#/#NAME#:#VERSION#
+manifests:
+  - image: #ORGNAME#/#NAME#:#VERSION#-x86_64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: #ORGNAME#/#NAME#:#VERSION#-ppc64le
+    platform:
+      architecture: ppc64le
+      os: linux


### PR DESCRIPTION
The existing Makefile requires your own create the mainfest spec file for different dockerhub organizaiton, for example, `xcatdevops`, this PR is to auto-generate it with a `.in` template.

```
make manifest USER=robin2008 VERSION=latest DOCKER_BUILD_MANIFEST=manifest/xcat.yml.in
Makefile:28: IMAGE=docker.io/robin2008/xcat2 VERSION=latest TAG=2.14.6-x86_64
generate manifest file from manifest/xcat.yml.in...
sed "s/#NAME#/xcat2/g; s/#ORGNAME#/robin2008/g; s/#VERSION#/2.14.6/g" \
		manifest/xcat.yml.in > /tmp/2.14.6.yml
cat /tmp/2.14.6.yml
image: robin2008/xcat2:2.14.6
manifests:
  - image: robin2008/xcat2:2.14.6-x86_64
    platform:
      architecture: amd64
      os: linux
  - image: robin2008/xcat2:2.14.6-ppc64le
    platform:
      architecture: ppc64le
      os: linux
INFO: create manifest docker.io/robin2008/xcat2:2.14.6 from manifest/xcat.yml.in...
docker run --rm \
		-v /tmp/2.14.6.yml:/xcat2.yml \
		-v /Users/binxu/.docker:/tmp/docker-cfg \
		mplatform/manifest-tool --debug  --docker-cfg '/tmp/docker-cfg'  \
		push from-spec /xcat2.yml
time="2019-04-21T03:48:38Z" level=debug msg="endpoints: [{false https://registry-1.docker.io v2 false true true 0xc00008c900}]"
time="2019-04-21T03:48:38Z" level=debug msg="repoName: robin2008/xcat2"
time="2019-04-21T03:48:38Z" level=info msg="Retrieving digests of images..."
time="2019-04-21T03:48:38Z" level=debug msg="authConfig for docker.io: "
time="2019-04-21T03:48:38Z" level=debug msg="endpoints: [{false https://registry-1.docker.io v2 false true true 0xc00008ca80}]"
time="2019-04-21T03:48:38Z" level=debug msg="Trying to fetch image manifest of docker.io/robin2008/xcat2 repository from https://registry-1.docker.io v2"
```