### PR TITLE
Adding centos 7.9 tag to centos image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM centos:7.9.2009
 
 MAINTAINER The xCAT Project
 


### PR DESCRIPTION
Generic "centos" image callout breaks now that it's pulling latest centos 8 images.

Centos 8 images have dhcp installed and line 21: mkdir -p /xcatdata/etc/{dhcp,goconserver,xcat} && ln -sf -t /etc /xcatdata/etc/{dhcp,goconserver,xcat} breaks because ln can't overwrite /etc/dhcp with an empty dir